### PR TITLE
Use error.formatted for task fails

### DIFF
--- a/tasks/task.js
+++ b/tasks/task.js
@@ -91,7 +91,7 @@ class Task {
             message: error.message
         });
 
-        return console.error(`${this.chalk.white.bgRed.bold(' Error ')}\t\t${error.message}`);
+        return console.error(`${this.chalk.white.bgRed.bold(' Error ')}\t\t${error.formatted}`);
     }
 
     /**


### PR DESCRIPTION
Let's introduce a simple error to the stylesheet

```
$global-colors: (
    black: #000000,
    blue: #1c65d9,
    gray: #3c3c3b,
    gray-light: #9c9c9c,
    gray-lighter: #c8c8c8,
    gray-lightest: #e0e0e0,
    green: #006e33,
    purple: #673ab7,
    red: #ff3333,
    white: #fff
    yellow: #fac135
);
```

Note the missing ```,``` at the end of the second last item in the map.

When running `node build`, you'll get the following output:

```
Styles		Starting task...
 Error 		unclosed parenthesis`
```

Using `error.formatted` instead of `error.message` will give you this

```
Styles		Starting task...
 Error 		Error: unclosed parenthesis
        on line 15 of src/scss/meta/_config.scss
>>     yellow: #fac135
   ----^
```

Aah, better. What do you think?