### PR TITLE
Use error.formatted for task fails

### DIFF
--- a/tasks/task.js
+++ b/tasks/task.js
@@ -91,7 +91,7 @@ class Task {
             message: error.message
         });
 
-        return console.error(`${this.chalk.white.bgRed.bold(' Error ')}\t\t${error.message}`);
+        return console.error(`${this.chalk.white.bgRed.bold(' Error ')}\t\t${error.formatted}`);
     }
 
     /**


### PR DESCRIPTION
Replaces #2 and uses `develop` as the target branch